### PR TITLE
Add config option to disable mod, and add inspector scroll compatibility option

### DIFF
--- a/NoTankControls/NoTankControls.csproj
+++ b/NoTankControls/NoTankControls.csproj
@@ -1,69 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9A0201A2-AC1B-4541-B027-A42EA43ED9B3}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NoTankControls</RootNamespace>
-    <AssemblyName>NoTankControls</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <AssemblyTitle>NoTankControls</AssemblyTitle>
+    <Company>Nytra</Company>
+    <Product>NoTankControls</Product>
+    <Copyright>Copyright © Nytra 2025</Copyright>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <FileVersion>1.1.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\rml_libs\0Harmony.dll</HintPath>
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\rml_libs\0Harmony-Net9.dll</HintPath>
     </Reference>
     <Reference Include="FrooxEngine">
-      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\FrooxEngine.dll</HintPath>
     </Reference>
     <Reference Include="ResoniteModLoader">
       <HintPath>G:\SteamLibrary\steamapps\common\Resonite\Libraries\ResoniteModLoader.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Compile Include="XyMod.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+	<Reference Include="Renderite.Shared">
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\Renderite.Shared.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Content Include=".gitignore" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "G:\SteamLibrary\steamapps\common\Resonite\rml_mods\"</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-         Other similar extension points exist, see Microsoft.Common.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-    -->
 </Project>

--- a/NoTankControls/NoTankControls.csproj
+++ b/NoTankControls/NoTankControls.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyTitle>NoTankControls</AssemblyTitle>
     <Company>Nytra</Company>

--- a/NoTankControls/NoTankControls.csproj
+++ b/NoTankControls/NoTankControls.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="XyMod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -55,6 +56,9 @@
     <Content Include=".gitignore" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(TargetDir)\$(TargetFileName)" "G:\SteamLibrary\steamapps\common\Resonite\rml_mods\"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">

--- a/NoTankControls/NoTankControls.csproj
+++ b/NoTankControls/NoTankControls.csproj
@@ -1,71 +1,65 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{9A0201A2-AC1B-4541-B027-A42EA43ED9B3}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>NoTankControls</RootNamespace>
-        <AssemblyName>NoTankControls</AssemblyName>
-        <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="0Harmony">
-          <HintPath>D:\ResoDLL\0Harmony.dll</HintPath>
-        </Reference>
-        <Reference Include="BaseX">
-          <HintPath>D:\ResoDLL\BaseX.dll</HintPath>
-        </Reference>
-        <Reference Include="BaseX, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-          <HintPath>D:\ResoDLL\BaseX.dll</HintPath>
-        </Reference>
-        <Reference Include="FrooxEngine">
-          <HintPath>D:\ResoDLL\FrooxEngine.dll</HintPath>
-        </Reference>
-        <Reference Include="ResoniteModLoader">
-          <HintPath>D:\ResoDLL\ResoniteModLoader.dll</HintPath>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="XyMod.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include=".gitignore" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A0201A2-AC1B-4541-B027-A42EA43ED9B3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NoTankControls</RootNamespace>
+    <AssemblyName>NoTankControls</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\rml_libs\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="FrooxEngine">
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="ResoniteModLoader">
+      <HintPath>G:\SteamLibrary\steamapps\common\Resonite\Libraries\ResoniteModLoader.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="XyMod.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include=".gitignore" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>
     <Target Name="AfterBuild">
     </Target>
     -->
-
 </Project>

--- a/NoTankControls/Properties/AssemblyInfo.cs
+++ b/NoTankControls/Properties/AssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.10")]
+[assembly: AssemblyFileVersion("1.1.0")]

--- a/NoTankControls/Properties/AssemblyInfo.cs
+++ b/NoTankControls/Properties/AssemblyInfo.cs
@@ -7,9 +7,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("NoTankControls")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Nytra")]
 [assembly: AssemblyProduct("NoTankControls")]
-[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyCopyright("Copyright © Nytra 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyFileVersion("1.10")]

--- a/NoTankControls/Properties/AssemblyInfo.cs
+++ b/NoTankControls/Properties/AssemblyInfo.cs
@@ -1,15 +1,5 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NoTankControls")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Nytra")]
-[assembly: AssemblyProduct("NoTankControls")]
-[assembly: AssemblyCopyright("Copyright © Nytra 2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,16 +10,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("9A0201A2-AC1B-4541-B027-A42EA43ED9B3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]

--- a/NoTankControls/XyMod.cs
+++ b/NoTankControls/XyMod.cs
@@ -1,6 +1,7 @@
 ﻿using FrooxEngine;
 using HarmonyLib;
 using ResoniteModLoader;
+using Renderite.Shared;
 
 namespace NoTankControls
 {
@@ -8,7 +9,7 @@ namespace NoTankControls
 	{
 		public override string Name => "NoTankControls";
 		public override string Author => "zyntaks / Nytra";
-		public override string Version => "1.1.0";
+		public override string Version => "1.1.1";
 		public override string Link => "https://github.com/Nytra/NoTankControls";
 
 		public static ModConfiguration Config;

--- a/NoTankControls/XyMod.cs
+++ b/NoTankControls/XyMod.cs
@@ -1,33 +1,59 @@
-﻿using System;
+﻿using FrooxEngine;
 using HarmonyLib;
 using ResoniteModLoader;
-using FrooxEngine;
-using FrooxEngine.UIX;
 
 namespace NoTankControls
 {
-    public class XyMod : ResoniteMod
-    {
-        public override string Name => "NoTankControls";
-        public override string Author => "zyntaks";
-        public override string Version => "1.0.0";
-        public override string Link => "https://github.com/furrz/NoTankControls";
+	public class XyMod : ResoniteMod
+	{
+		public override string Name => "NoTankControls";
+		public override string Author => "zyntaks";
+		public override string Version => "1.0.0";
+		public override string Link => "https://github.com/furrz/NoTankControls";
 
-        private static bool _first_trigger = false;
-        public override void OnEngineInit()
-        {
-            Harmony harmony = new Harmony("U-xyla.XyMod");
-            harmony.PatchAll();
-        }
+		public static ModConfiguration Config;
 
-        [HarmonyPatch(typeof(InteractionHandler))]
-        [HarmonyPatch("BeforeInputUpdate")]
-        class Patch
-        {
-            private static void Postfix(InteractionHandler __instance, ref InteractionHandlerInputs ____inputs)
-            {
-                ____inputs.Axis.RegisterBlocks = false;
-            }
-        }
-    }
+		[AutoRegisterConfigKey]
+		private static ModConfigurationKey<bool> MOD_ENABLED = new ModConfigurationKey<bool>("MOD_ENABLED", "Mod Enabled:", () => true);
+		[AutoRegisterConfigKey]
+		private static ModConfigurationKey<bool> INSPECTOR_SCROLL_COMPATIBILITY = new ModConfigurationKey<bool>("INSPECTOR_SCROLL_COMPATIBILITY", "Use inspector scroll compatibility:", () => false);
+
+		public override void OnEngineInit()
+		{
+			Config = GetConfiguration();
+			SetupMod();
+		}
+
+		static void SetupMod()
+		{
+			Harmony harmony = new Harmony("U-xyla.XyMod");
+			harmony.PatchAll();
+		}
+
+		[HarmonyPatch(typeof(InteractionHandler))]
+		[HarmonyPatch("BeforeInputUpdate")]
+		class Patch
+		{
+			private static void Postfix(InteractionHandler __instance, ref InteractionHandlerInputs ____inputs)
+			{
+				if (Config.GetValue(MOD_ENABLED))
+				{
+					if (Config.GetValue(INSPECTOR_SCROLL_COMPATIBILITY))
+					{
+						IAxisActionReceiver axisActionReceiver = __instance.Laser.CurrentTouchable as IAxisActionReceiver;
+						if (axisActionReceiver != null)
+						{
+							if (((__instance.ActiveTool != null && __instance.ActiveTool.UsesSecondary) ||
+								__instance.InputInterface.GetControllerNode(__instance.Side).GetType() == typeof(IndexController)) && !__instance.InputInterface.ScreenActive)
+							{
+								____inputs.Axis.RegisterBlocks = true;
+								return;
+							}
+						}
+					}
+					____inputs.Axis.RegisterBlocks = false;
+				}
+			}
+		}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Neos-Metaverse/NeosPublic#1969 seems related.
 
 ## Installation
 1. Install the appropriate modloader.
-1. Place [NoTankControls.dll](https://github.com/furrz/NoTankControls/releases/latest/download/NoTankControls.dll) into your `nml_mods` or `rml_mods` folder. Make sure to use an older release if on neos, the latest DLL download is for Resonite! You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
-1. Start the game. If you want to verify that the mod is working you can check your game logs, or try moving around with the DevToolTip equipped!
+2. Place [NoTankControls.dll](https://github.com/Nytra/NoTankControls/releases/tag/v1.1.0) into your `nml_mods` or `rml_mods` folder. Make sure to use an older release if on neos, the latest DLL download is for Resonite! You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
+3. Start the game. If you want to verify that the mod is working you can check your game logs, or try moving around with the DevToolTip equipped!

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Neos/Resonite disables the joystick if you have a tooltip equipped which makes u
 (pressing down on that same joystick.)
 This mod removes that restriction, allowing tools to be equipped while keeping full movement intact.
 
+This version of the mod also has an option to enable compatibility with the InspectorScroll mod. When this is enabled and you point at UIX while holding a tool that stick's locomotion input will be disabled to allow for easier scrolling of the inspector.
+
 ## Relavent Issue
 Neos-Metaverse/NeosPublic#1969 seems related.
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # NoTankControls
 
-A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader) and
-[NeosModLoader](https://github.com/zkxs/NeosModLoader) mod for [Resonite](https://resonite.com/) that allows you to move with your joysticks while holding any tool.
+A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader) mod for [Resonite](https://resonite.com/) that allows you to move with your joysticks while holding any tool.
 
-Neos/Resonite disables the joystick if you have a tooltip equipped which makes use of the "Secondary" action
+Resonite disables the joystick if you have a tooltip equipped which makes use of the "Secondary" action
 (pressing down on that same joystick.)
 This mod removes that restriction, allowing tools to be equipped while keeping full movement intact.
 
 This version of the mod also has an option to enable compatibility with the InspectorScroll mod. When this is enabled and you point at UIX while holding a tool that stick's locomotion input will be disabled to allow for easier scrolling of the inspector.
 
-## Relavent Issue
-Neos-Metaverse/NeosPublic#1969 seems related.
+## Relevant Issue
+https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/2339
 
 ## Installation
-1. Install the appropriate modloader.
+1. Install the modloader.
 2. Place [NoTankControls.dll](https://github.com/Nytra/NoTankControls/releases/download/v1.1.0/NoTankControls.dll) into your `rml_mods` folder. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
 3. Start the game. If you want to verify that the mod is working you can check your game logs, or try moving around with the DevToolTip equipped!

--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Neos-Metaverse/NeosPublic#1969 seems related.
 
 ## Installation
 1. Install the appropriate modloader.
-2. Place [NoTankControls.dll](https://github.com/Nytra/NoTankControls/releases/tag/v1.1.0) into your `nml_mods` or `rml_mods` folder. Make sure to use an older release if on neos, the latest DLL download is for Resonite! You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
+2. Place [NoTankControls.dll](https://github.com/furrz/NoTankControls/releases/latest/download/NoTankControls.dll) into your `nml_mods` or `rml_mods` folder. Make sure to use an older release if on neos, the latest DLL download is for Resonite! You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
 3. Start the game. If you want to verify that the mod is working you can check your game logs, or try moving around with the DevToolTip equipped!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # NoTankControls
 
 A [ResoniteModLoader](https://github.com/resonite-modding-group/ResoniteModLoader) and
-[NeosModLoader](https://github.com/zkxs/NeosModLoader) mod for Resonite and [Neos VR](https://neos.com/)
-that allows you to move with your joysticks while holding any tool.
+[NeosModLoader](https://github.com/zkxs/NeosModLoader) mod for [Resonite](https://resonite.com/) that allows you to move with your joysticks while holding any tool.
 
 Neos/Resonite disables the joystick if you have a tooltip equipped which makes use of the "Secondary" action
 (pressing down on that same joystick.)
@@ -15,5 +14,5 @@ Neos-Metaverse/NeosPublic#1969 seems related.
 
 ## Installation
 1. Install the appropriate modloader.
-2. Place [NoTankControls.dll](https://github.com/furrz/NoTankControls/releases/latest/download/NoTankControls.dll) into your `nml_mods` or `rml_mods` folder. Make sure to use an older release if on neos, the latest DLL download is for Resonite! You can create it if it's missing, or if you launch the game once with NeosModLoader installed it will create the folder for you.
+2. Place [NoTankControls.dll](https://github.com/Nytra/NoTankControls/releases/download/v1.1.0/NoTankControls.dll) into your `rml_mods` folder. You can create it if it's missing, or if you launch the game once with ResoniteModLoader installed it will create the folder for you.
 3. Start the game. If you want to verify that the mod is working you can check your game logs, or try moving around with the DevToolTip equipped!


### PR DESCRIPTION
This adds some config options for use with ResoniteModSettings. One is just to turn off the mod. The other is to allow better compatibility with the InspectorScroll mod. When the InspectorScroll config option is active, if you point at a UIX canvas while holding a tool it will lock your turning to allow scrolling on the canvas more easily without accidentally turning.

You will need to add your Resonite DLL references back to the .csproj, and probably want to bump the mod version number if you release this.